### PR TITLE
emit before transfer (#446)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,6 @@
     },
     "asciidoc.antora.enableAntoraSupport": true,
     "security.olympix.project.includePath": "/contracts",
-    "solidity.defaultCompiler": "localNodeModule",
+    "solidity.defaultCompiler": "localFile",
     "solidity.compileUsingLocalVersion": "/workspaces/gif-next/soljson-v0.8.26+commit.8a97fa7a.js",
 }

--- a/contracts/distribution/DistributionService.sol
+++ b/contracts/distribution/DistributionService.sol
@@ -298,10 +298,9 @@ contract DistributionService is
         // transfer amount to distributor
         {
             address distributor = getRegistry().ownerOf(distributorNftId);
+            emit LogDistributionServiceCommissionWithdrawn(distributorNftId, distributor, address(token), withdrawnAmount);
             // TODO: centralize token handling (issue #471)
             distributionInfo.tokenHandler.transfer(distributionWallet, distributor, withdrawnAmount);
-
-            emit LogDistributionServiceCommissionWithdrawn(distributorNftId, distributor, address(token), withdrawnAmount);
         }
     }
 

--- a/contracts/instance/module/IPolicy.sol
+++ b/contracts/instance/module/IPolicy.sol
@@ -22,7 +22,7 @@ interface IPolicy {
         uint256 netPremiumAmount;
         // fullPremium = netPremium + all fixed amounts + all variable amounts (excl commission and minDistribtuionOwnerFee variable part)
         uint256 fullPremiumAmount;
-        // premium = fullPremium - discount
+        // effective premium = fullPremium - discount 
         uint256 premiumAmount;
         uint256 productFeeFixAmount;
         uint256 poolFeeFixAmount;

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -409,10 +409,9 @@ contract BundleService is
         // transfer amount to bundle owner
         {
             address owner = getRegistry().ownerOf(bundleNftId);
+            emit LogBundleServiceFeesWithdrawn(bundleNftId, owner, address(token), withdrawnAmount);
             // TODO: centralize token handling (issue #471)
             poolInfo.tokenHandler.transfer(poolWallet, owner, withdrawnAmount);
-
-            emit LogBundleServiceFeesWithdrawn(bundleNftId, owner, address(token), withdrawnAmount);
         }
     }
 

--- a/contracts/pool/PoolService.sol
+++ b/contracts/pool/PoolService.sol
@@ -222,13 +222,12 @@ contract PoolService is
 
         // collect tokens from bundle owner
         address bundleOwner = getRegistry().ownerOf(bundleNftId);
+        emit LogPoolServiceBundleStaked(instance.getNftId(), poolNftId, bundleNftId, amount, netAmount);
         _collectStakingAmount(
             instanceReader, 
             poolNftId, 
             bundleOwner, 
             amount);
-
-        emit LogPoolServiceBundleStaked(instance.getNftId(), poolNftId, bundleNftId, amount, netAmount);
     }
 
     /// @inheritdoc IPoolService
@@ -280,11 +279,9 @@ contract PoolService is
 
         // transfer amount to bundle owner
         address owner = getRegistry().ownerOf(bundleNftId);
+        emit LogPoolServiceBundleUnstaked(instance.getNftId(), poolNftId, bundleNftId, unstakedAmount);
         // TODO: centralize token handling (issue #471)
         poolComponentInfo.tokenHandler.transfer(poolWallet, owner, unstakedAmount);
-        
-        emit LogPoolServiceBundleUnstaked(instance.getNftId(), poolNftId, bundleNftId, unstakedAmount);
-
         return unstakedAmount;
     }
 

--- a/contracts/product/IClaimService.sol
+++ b/contracts/product/IClaimService.sol
@@ -31,6 +31,7 @@ interface IClaimService is
     error ErrorClaimServicePolicyProductMismatch(NftId policyNftId, NftId expectedProduct, NftId actualProduct);
     error ErrorClaimServicePolicyNotOpen(NftId policyNftId);
     error ErrorClaimServiceClaimExceedsSumInsured(NftId policyNftId, Amount sumInsured, Amount payoutsIncludingClaimAmount);
+    error ErrorClaimsServicePayoutAmountIsZero(NftId policyNftId, PayoutId payoutId);
 
     error ErrorClaimServiceClaimWithOpenPayouts(NftId policyNftId, ClaimId claimId, uint8 openPayouts);
     error ErrorClaimServiceClaimWithMissingPayouts(NftId policyNftId, ClaimId claimId, Amount claimAmount, Amount paidAmount);

--- a/contracts/product/IPolicyService.sol
+++ b/contracts/product/IPolicyService.sol
@@ -22,7 +22,7 @@ interface IPolicyService is IService {
     error ErrorPolicyServicePolicyStateNotApplied(NftId applicationNftId);
     error ErrorPolicyServicePolicyStateNotCollateralizedOrApplied(NftId applicationNftId);
 
-    error ErrorPolicyServicePremiumHigherThanExpected(Amount premiumExpectedAmount, Amount premiumToBePaidAmount);
+    error ErrorPolicyServicePremiumHigherThanExpected(uint256 premiumExpectedAmount, uint256 premiumToBePaidAmount);
     error ErrorPolicyServiceBalanceInsufficient(address policyOwner, uint256 premiumAmount, uint256 balance);
     error ErrorPolicyServiceAllowanceInsufficient(address policyOwner, address tokenHandler, uint256 premiumAmount, uint256 allowance);
 
@@ -43,7 +43,7 @@ interface IPolicyService is IService {
     event LogPolicyServicePolicyDeclined(NftId policyNftId);
     event LogPolicyServicePolicyExpirationUpdated(NftId policyNftId, Timestamp expiredAt);
 
-    /// @dev collateralizes the policy represented by {policyNftId}
+    /// @dev collateralizes the policy represented by {policyNftId}. locks the sum insured amount in the pool.
     /// sets the policy state to collateralized
     /// may set the policy state to activated and set the activation date
     /// optionally collects premiums and activates the policy.
@@ -62,7 +62,7 @@ interface IPolicyService is IService {
     /// only the related product may decline an application
     function decline(NftId policyNftId) external;
 
-    /// @dev collects the premium token for the specified policy
+    /// @dev collects the premium token for the specified policy (must be in COLLATERALIZED or ACTIVE state)
     function collectPremium(NftId policyNftId, Timestamp activateAt) external;
 
     /// @dev activates the specified policy and sets the activation date in the policy metadata

--- a/contracts/shared/Component.sol
+++ b/contracts/shared/Component.sol
@@ -6,7 +6,7 @@ import {IAccessManaged} from "@openzeppelin/contracts/access/manager/IAccessMana
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {Amount} from "../type/Amount.sol";
+import {Amount, AmountLib} from "../type/Amount.sol";
 import {IComponent} from "./IComponent.sol";
 import {IComponents} from "../instance/module/IComponents.sol";
 import {NftId, NftIdLib} from "../type/NftId.sol";
@@ -132,7 +132,7 @@ abstract contract Component is
                 // move tokens from component smart contract to external wallet
             } else {
                 // move tokens from external wallet to component smart contract or another external wallet
-                uint256 allowance = token.allowance(currentWallet, address(this));
+                uint256 allowance = token.allowance(currentWallet, address(getTokenHandler()));
                 if (allowance < currentBalance) {
                     revert ErrorComponentWalletAllowanceTooSmall(currentWallet, newWallet, allowance, currentBalance);
                 }
@@ -147,11 +147,11 @@ abstract contract Component is
             // transfer tokens from current wallet to new wallet
             if (currentWallet == address(this)) {
                 // transferFrom requires self allowance too
-                token.approve(address(this), currentBalance);
+                token.approve(address(getTokenHandler()), currentBalance);
             }
             
-            SafeERC20.safeTransferFrom(token, currentWallet, newWallet, currentBalance);
             emit LogComponentWalletTokensTransferred(currentWallet, newWallet, currentBalance);
+            getTokenHandler().transfer(currentWallet, newWallet, AmountLib.toAmount(currentBalance));
         }
     }
 

--- a/contracts/shared/Component.sol
+++ b/contracts/shared/Component.sol
@@ -109,11 +109,11 @@ abstract contract Component is
             revert ErrorComponentWalletNotComponent();
         }
 
+        emit LogComponentTokenHandlerApproved(address(getTokenHandler()), spendingLimitAmount);
+
         IERC20Metadata(token).approve(
             address(getTokenHandler()),
             spendingLimitAmount.toInt());
-
-        emit LogComponentTokenHandlerApproved(address(getTokenHandler()), spendingLimitAmount);
     }
 
     function setWallet(address newWallet)
@@ -144,13 +144,14 @@ abstract contract Component is
 
         // interactions
         if (currentBalance > 0) {
+            emit LogComponentWalletTokensTransferred(currentWallet, newWallet, currentBalance);
+
             // transfer tokens from current wallet to new wallet
             if (currentWallet == address(this)) {
                 // transferFrom requires self allowance too
                 token.approve(address(getTokenHandler()), currentBalance);
             }
             
-            emit LogComponentWalletTokensTransferred(currentWallet, newWallet, currentBalance);
             getTokenHandler().transfer(currentWallet, newWallet, AmountLib.toAmount(currentBalance));
         }
     }

--- a/contracts/shared/ComponentService.sol
+++ b/contracts/shared/ComponentService.sol
@@ -128,10 +128,9 @@ contract ComponentService is
         
         // transfer amount to component owner
         address componentOwner = getRegistry().ownerOf(componentNftId);
+        emit LogComponentServiceComponentFeesWithdrawn(componentNftId, componentOwner, address(token), withdrawnAmount);
         // TODO: centralize token handling (issue #471)
         tokenHandler.transfer(componentWallet, componentOwner, withdrawnAmount);
-
-        emit LogComponentServiceComponentFeesWithdrawn(componentNftId, componentOwner, address(token), withdrawnAmount);
     }
 
 

--- a/contracts/shared/IComponent.sol
+++ b/contracts/shared/IComponent.sol
@@ -35,10 +35,11 @@ interface IComponent is
     /// only component owner (nft holder) is authorizes to call this function
     function approveTokenHandler(Amount spendingLimitAmount) external;
 
-    /// @dev sets the wallet address for the component
-    /// if the current wallet has tokens, these will be transferred
+    /// @dev sets the wallet address for the component.
+    /// if the current wallet has tokens, these will be transferred.
     /// if the new wallet address is externally owned, an approval from the 
-    /// owner of the external wallet for the component to move all tokens must exist
+    /// owner of the external wallet to the tokenhandler of the component that 
+    /// covers the current component balance must exist
     function setWallet(address walletAddress) external;
 
     /// @dev returns the name of this component

--- a/contracts/shared/TokenHandler.sol
+++ b/contracts/shared/TokenHandler.sol
@@ -10,6 +10,8 @@ import {Amount} from "../type/Amount.sol";
 /// a default token contract is provided via contract constructor
 /// relies internally on oz SafeERC20.safeTransferFrom
 contract TokenHandler {
+    event LogTokenHandlerTokenTransfer(address token, address from, address to, uint256 amount);
+
     IERC20Metadata private _token;
 
     constructor(address token) {
@@ -24,6 +26,7 @@ contract TokenHandler {
     )
         external
     {
+        emit LogTokenHandlerTokenTransfer(address(_token), from, to, amount.toInt());
         SafeERC20.safeTransferFrom(
             _token, 
             from, 
@@ -40,6 +43,7 @@ contract TokenHandler {
     )
         external
     {
+        emit LogTokenHandlerTokenTransfer(token, from, to, amount.toInt());
         SafeERC20.safeTransferFrom(
             IERC20Metadata(token), 
             from, 

--- a/contracts/staking/StakingService.sol
+++ b/contracts/staking/StakingService.sol
@@ -122,11 +122,10 @@ contract StakingService is
 
         // transfer withdrawal amount to target owner
         address instanceOwner = getRegistry().ownerOf(instanceNftId);
+        emit LogStakingServiceRewardReservesDecreased(instanceNftId, instanceOwner, dipAmount, newBalance);
         $._staking.transferDipAmount(
             instanceOwner,
             dipAmount);
-
-        emit LogStakingServiceRewardReservesDecreased(instanceNftId, instanceOwner, dipAmount, newBalance);
     }
 
 
@@ -169,12 +168,12 @@ contract StakingService is
             targetNftId,
             dipAmount);
 
+        emit LogStakingServiceStakeCreated(stakeNftId, targetNftId, stakeOwner, dipAmount);
+
         // collect staked dip by staking
         $._staking.collectDipAmount(
             stakeOwner,
             dipAmount);
-
-        emit LogStakingServiceStakeCreated(stakeNftId, targetNftId, stakeOwner, dipAmount);
     }
 
 
@@ -197,12 +196,11 @@ contract StakingService is
 
         // collect staked dip by staking
         if (dipAmount.gtz()) {
+            emit LogStakingServiceStakeIncreased(stakeNftId, stakeOwner, dipAmount, stakeBalance);
             $._staking.collectDipAmount(
                 stakeOwner,
                 dipAmount);
         }
-
-        emit LogStakingServiceStakeIncreased(stakeNftId, stakeOwner, dipAmount, stakeBalance);
     }
 
 
@@ -247,11 +245,10 @@ contract StakingService is
         address stakeOwner = msg.sender;
 
         Amount rewardsClaimedAmount = $._staking.claimRewards(stakeNftId);
+        emit LogStakingServiceRewardsClaimed(stakeNftId, stakeOwner, rewardsClaimedAmount);
         $._staking.transferDipAmount(
             stakeOwner,
             rewardsClaimedAmount);
-
-        emit LogStakingServiceRewardsClaimed(stakeNftId, stakeOwner, rewardsClaimedAmount);
     }
 
 
@@ -270,11 +267,10 @@ contract StakingService is
         ) = $._staking.unstake(stakeNftId);
 
         Amount totalAmount = unstakedAmount + rewardsClaimedAmount;
+        emit LogStakingServiceUnstaked(stakeNftId, stakeOwner, totalAmount);
         $._staking.transferDipAmount(
             stakeOwner,
             totalAmount);
-
-        emit LogStakingServiceUnstaked(stakeNftId, stakeOwner, totalAmount);
     }
 
 
@@ -389,12 +385,12 @@ contract StakingService is
         StakingServiceStorage storage $ = _getStakingServiceStorage();
         newBalance = $._staking.refillRewardReserves(targetNftId, dipAmount);
 
+        emit LogStakingServiceRewardReservesIncreased(targetNftId, rewardProvider, dipAmount, newBalance);
+
         // collect reward dip from provider
         $._staking.collectDipAmount(
             rewardProvider,
             dipAmount);
-
-        emit LogStakingServiceRewardReservesIncreased(targetNftId, rewardProvider, dipAmount, newBalance);
     }
 
 

--- a/test/TestDistribution.t.sol
+++ b/test/TestDistribution.t.sol
@@ -178,7 +178,7 @@ contract TestDistribution is GifTest {
 
         // allowance from externally owned wallet to distribution component
         vm.startPrank(externallyOwnedWallet);
-        token.approve(address(distribution), INITIAL_BALANCE);
+        token.approve(address(distribution.getTokenHandler()), INITIAL_BALANCE);
         vm.stopPrank();
 
         vm.startPrank(distributionOwner);
@@ -238,7 +238,7 @@ contract TestDistribution is GifTest {
 
         // allowance from externally owned wallet to distribution component
         vm.startPrank(externallyOwnedWallet);
-        token.approve(address(distribution), INITIAL_BALANCE);
+        token.approve(address(distribution.getTokenHandler()), INITIAL_BALANCE);
         vm.stopPrank();
 
         vm.startPrank(distributionOwner);

--- a/test/component/product/ProductPayout.t.sol
+++ b/test/component/product/ProductPayout.t.sol
@@ -214,10 +214,10 @@ contract TestProductClaim is GifTest {
 
         // THEN
         // checking last of 8 logs
-        assertEq(entries.length, 8, "unexpected number of logs");
-        assertEq(entries[7].emitter, address(claimService), "unexpected emitter");
-        assertEq(entries[7].topics[0], keccak256("LogClaimServicePayoutProcessed(uint96,uint24,uint96,address,uint96)"), "unexpected log signature");
-        (uint96 nftIdInt ,uint24 payoutIdInt, uint96 payoutAmntInt) = abi.decode(entries[7].data, (uint96,uint24,uint96));
+        assertEq(entries.length, 9, "unexpected number of logs");
+        assertEq(entries[8].emitter, address(claimService), "unexpected emitter");
+        assertEq(entries[8].topics[0], keccak256("LogClaimServicePayoutProcessed(uint96,uint24,uint96,address,uint96)"), "unexpected log signature");
+        (uint96 nftIdInt ,uint24 payoutIdInt, uint96 payoutAmntInt) = abi.decode(entries[8].data, (uint96,uint24,uint96));
         assertEq(nftIdInt, policyNftId.toInt(), "unexpected policy nft id");
         assertEq(payoutIdInt, payoutId.toInt(), "unexpected payout id");
         assertEq(payoutAmntInt, payoutAmountInt, "unexpected payout amount");

--- a/test/component/product/ProductPayout.t.sol
+++ b/test/component/product/ProductPayout.t.sol
@@ -215,9 +215,9 @@ contract TestProductClaim is GifTest {
         // THEN
         // checking last of 8 logs
         assertEq(entries.length, 9, "unexpected number of logs");
-        assertEq(entries[8].emitter, address(claimService), "unexpected emitter");
-        assertEq(entries[8].topics[0], keccak256("LogClaimServicePayoutProcessed(uint96,uint24,uint96,address,uint96)"), "unexpected log signature");
-        (uint96 nftIdInt ,uint24 payoutIdInt, uint96 payoutAmntInt) = abi.decode(entries[8].data, (uint96,uint24,uint96));
+        assertEq(entries[6].topics[0], keccak256("LogClaimServicePayoutProcessed(uint96,uint24,uint96,address,uint96)"), "unexpected log signature");
+        assertEq(entries[6].emitter, address(claimService), "unexpected emitter");
+        (uint96 nftIdInt ,uint24 payoutIdInt, uint96 payoutAmntInt) = abi.decode(entries[6].data, (uint96,uint24,uint96));
         assertEq(nftIdInt, policyNftId.toInt(), "unexpected policy nft id");
         assertEq(payoutIdInt, payoutId.toInt(), "unexpected payout id");
         assertEq(payoutAmntInt, payoutAmountInt, "unexpected payout amount");


### PR DESCRIPTION
# ERC20 transfers (direct)

- [x] Component.setWallet 
- [x] Switch `Component.setWallet` to use TokenHandler

# TokenHandler.safeTransferFrom()

- [x] not used by anyone

# TokenHandler.transfer()

**Note**: Prefix X means trace to _externally callable_ function not completed

- [x] Distribution.withdrawCommission via DistributionService.withdrawCommission
- [x] Pool.withdrawBundleFees via BundleService.withdrawBundleFees
- [x] BasicPool.unstake via Pool._unstake via PoolService.unstake
- [x] Pool._unstake via PoolService.unstake
- [x] Pool._createBundle via PoolService.createBundle via _collectStakingAmount
- [x] BasicPool.stake via Pool._stake PoolService.stake via _collectStakingAmount
- [x] Pool._stake via PoolService.stake via _collectStakingAmount
- [x] Product._processPayout via ClaimService.processPayout via _transferPayoutAmount
- [x] Product._collateralize via PolicyService.collateralize via _processSaleAndTransferFunds
- [x] Product._collectPremium via PolicyService.collectPremium via _processSaleAndTransferFunds
- [x] InstanceLinkedComponent.withdrawFees via InstanceLinkedComponent._withdrawFees via ComponentService.withdrawFees 
- [x] InstanceLinkedComponent._withdrawFees via ComponentService.withdrawFees 
- [x] StakingService.create via Staking.collectDipAmount
- [x] StakingService.stake via Staking.collectDipAmount
- [x] Instance.refillStakingRewardReserves via StakingService.refillInstanceRewardReserves via StakingService._refillRewardReserves via Staking.collectDipAmount
- [x] StakingService.refillRewardReservesBySender via StakingService._refillRewardReserves via Staking.collectDipAmount
- [x] Instance.withdrawStakingRewardReserves via InstanceService.withdrawStakingRewardReserves via StakingService.withdrawInstanceRewardReserves via Staking.transferDipAmount
- [x] StakingService.claimRewards via  Staking.transferDipAmount
- [x] StakingService.unstake via Staking.transferDipAmount
