### PR TITLE
implement PoolService.closeBundle (#475)

### DIFF
--- a/contracts/pool/BasicPool.sol
+++ b/contracts/pool/BasicPool.sol
@@ -108,13 +108,13 @@ abstract contract BasicPool is
     }
 
 
-    function close(NftId bundleNftId)
+    function closeBundle(NftId bundleNftId)
         public
         virtual
         restricted()
         onlyBundleOwner(bundleNftId)
     {
-        _close(bundleNftId);
+        _closeBundle(bundleNftId);
     }
 
 

--- a/contracts/pool/BasicPoolAuthorization.sol
+++ b/contracts/pool/BasicPoolAuthorization.sol
@@ -40,7 +40,7 @@ contract BasicPoolAuthorization
           _authorize(functions, BasicPool.extend.selector, "extend");
           _authorize(functions, BasicPool.lockBundle.selector, "lockBundle");
           _authorize(functions, BasicPool.unlockBundle.selector, "unlockBundle");
-          _authorize(functions, BasicPool.close.selector, "close");
+          _authorize(functions, BasicPool.closeBundle.selector, "closeBundle");
           _authorize(functions, BasicPool.setBundleFee.selector, "setBundleFee");
 
           _authorize(functions, BasicPool.setMaxCapitalAmount.selector, "setMaxCapitalAmount");

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -221,7 +221,6 @@ contract BundleService is
         restricted
         returns (Amount unstakedAmount, Amount feeAmount)
     {
-        // udpate bundle state
         InstanceReader instanceReader = instance.getInstanceReader();
 
         // ensure no open policies attached to bundle
@@ -232,14 +231,15 @@ contract BundleService is
         }
 
         {
-            Amount balanceAmountWithFees = instanceReader.getBalanceAmount(bundleNftId);
-            feeAmount = instanceReader.getFeeAmount(bundleNftId);
-            unstakedAmount = balanceAmountWithFees - feeAmount;
-
+            // update bundle state
             InstanceStore instanceStore = instance.getInstanceStore();
             instanceStore.updateBundleState(bundleNftId, CLOSED());
             bundleManager.lock(bundleNftId);
 
+            // decrease bundle counters
+            Amount balanceAmountWithFees = instanceReader.getBalanceAmount(bundleNftId);
+            feeAmount = instanceReader.getFeeAmount(bundleNftId);
+            unstakedAmount = balanceAmountWithFees - feeAmount;
             _componentService.decreaseBundleBalance(instanceStore, bundleNftId, unstakedAmount, feeAmount);
         }
     }

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -219,7 +219,7 @@ contract BundleService is
         external
         virtual
         restricted
-        returns (Amount balanceAmount, Amount feeAmount)
+        returns (Amount unstakedAmount, Amount feeAmount)
     {
         // udpate bundle state
         InstanceReader instanceReader = instance.getInstanceReader();
@@ -234,13 +234,13 @@ contract BundleService is
         {
             Amount balanceAmountWithFees = instanceReader.getBalanceAmount(bundleNftId);
             feeAmount = instanceReader.getFeeAmount(bundleNftId);
-            balanceAmount = balanceAmountWithFees - feeAmount;
+            unstakedAmount = balanceAmountWithFees - feeAmount;
 
             InstanceStore instanceStore = instance.getInstanceStore();
             instanceStore.updateBundleState(bundleNftId, CLOSED());
             bundleManager.lock(bundleNftId);
 
-            _componentService.decreaseBundleBalance(instanceStore, bundleNftId, balanceAmount, feeAmount);
+            _componentService.decreaseBundleBalance(instanceStore, bundleNftId, unstakedAmount, feeAmount);
         }
     }
 

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -230,17 +230,17 @@ contract BundleService is
         if(openPolicies > 0) {
             revert ErrorBundleServiceBundleWithOpenPolicies(bundleNftId, openPolicies);
         }
-        if(instanceReader.getLockedAmount(bundleNftId) > AmountLib.zero()) {
-            revert ErrorBundleServiceBundleWithLockedCollateral(bundleNftId, instanceReader.getLockedAmount(bundleNftId));
+
+        {
+            balanceAmount = instanceReader.getBalanceAmount(bundleNftId);
+            feeAmount = instanceReader.getFeeAmount(bundleNftId);
+
+            InstanceStore instanceStore = instance.getInstanceStore();
+            instanceStore.updateBundleState(bundleNftId, CLOSED());
+            bundleManager.lock(bundleNftId);
+
+            _componentService.decreaseBundleBalance(instanceStore, bundleNftId, balanceAmount, feeAmount);
         }
-
-        InstanceStore instanceStore = instance.getInstanceStore();
-        instanceStore.updateBundleState(bundleNftId, CLOSED());
-        bundleManager.lock(bundleNftId);
-
-        balanceAmount = instanceReader.getBalanceAmount(bundleNftId);
-        feeAmount = instanceReader.getFeeAmount(bundleNftId);
-        _componentService.decreaseBundleBalance(instanceStore, bundleNftId, balanceAmount, feeAmount);
     }
 
     /// @inheritdoc IBundleService

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -238,8 +238,8 @@ contract BundleService is
         instanceStore.updateBundleState(bundleNftId, CLOSED());
         bundleManager.lock(bundleNftId);
 
-        Amount balanceAmount = instanceReader.getBalanceAmount(bundleNftId);
-        Amount feeAmount = instanceReader.getFeeAmount(bundleNftId);
+        balanceAmount = instanceReader.getBalanceAmount(bundleNftId);
+        feeAmount = instanceReader.getFeeAmount(bundleNftId);
         _componentService.decreaseBundleBalance(instanceStore, bundleNftId, balanceAmount, feeAmount);
     }
 

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -232,8 +232,9 @@ contract BundleService is
         }
 
         {
-            balanceAmount = instanceReader.getBalanceAmount(bundleNftId);
+            Amount balanceAmountWithFees = instanceReader.getBalanceAmount(bundleNftId);
             feeAmount = instanceReader.getFeeAmount(bundleNftId);
+            balanceAmount = balanceAmountWithFees - feeAmount;
 
             InstanceStore instanceStore = instance.getInstanceStore();
             instanceStore.updateBundleState(bundleNftId, CLOSED());

--- a/contracts/pool/BundleService.sol
+++ b/contracts/pool/BundleService.sol
@@ -16,7 +16,7 @@ import {IPolicy} from "../instance/module/IPolicy.sol";
 import {Amount, AmountLib} from "../type/Amount.sol";
 import {BundleSet} from "../instance/BundleSet.sol";
 import {ComponentVerifyingService} from "../shared/ComponentVerifyingService.sol";
-import {Fee, FeeLib} from "../type/Fee.sol";
+import {Fee} from "../type/Fee.sol";
 import {InstanceReader} from "../instance/InstanceReader.sol";
 import {NftId, NftIdLib} from "../type/NftId.sol";
 import {ObjectType, COMPONENT, POOL, BUNDLE, REGISTRY} from "../type/ObjectType.sol";

--- a/contracts/pool/IBundleService.sol
+++ b/contracts/pool/IBundleService.sol
@@ -81,6 +81,8 @@ interface IBundleService is IService {
     /// only open bundles (active or locked) may be closed
     /// to close a bundle it may not have any non-closed polices attached to it
     /// may only be called by registered and unlocked pool components
+    /// @return balanceAmount the unstaked amount that was remaining in the bundle
+    /// @return feeAmount the fee amount that was remaining for the bundle
     function close(
         IInstance instance, 
         NftId bundleNftId

--- a/contracts/pool/IBundleService.sol
+++ b/contracts/pool/IBundleService.sol
@@ -31,7 +31,6 @@ interface IBundleService is IService {
     error ErrorBundleServiceWalletAllowanceTooSmall(address wallet, address tokenHandler, uint256 allowance, uint256 amount);
 
     error ErrorBundleServiceUnstakeAmountExceedsLimit(Amount amount, Amount limit);
-    error ErrorBundleServiceBundleWithLockedCollateral(NftId bundleNftId, Amount lockedCollateralAmount);
 
     error ErrorBundleServiceExtensionLifetimeIsZero();
 

--- a/contracts/pool/IBundleService.sol
+++ b/contracts/pool/IBundleService.sol
@@ -31,6 +31,7 @@ interface IBundleService is IService {
     error ErrorBundleServiceWalletAllowanceTooSmall(address wallet, address tokenHandler, uint256 allowance, uint256 amount);
 
     error ErrorBundleServiceUnstakeAmountExceedsLimit(Amount amount, Amount limit);
+    error ErrorBundleServiceBundleWithLockedCollateral(NftId bundleNftId, Amount lockedCollateralAmount);
 
     error ErrorBundleServiceExtensionLifetimeIsZero();
 
@@ -84,7 +85,7 @@ interface IBundleService is IService {
     function close(
         IInstance instance, 
         NftId bundleNftId
-    ) external;
+    ) external returns (Amount balanceAmount, Amount feeAmount);
 
     /// @dev set bundle fee to provided value
     /// may only be called by registered and unlocked pool components

--- a/contracts/pool/Pool.sol
+++ b/contracts/pool/Pool.sol
@@ -229,7 +229,7 @@ abstract contract Pool is
     /// To close a bundle all all linked policies MUST be in closed state as well.
     /// Closing a bundle finalizes the bundle bookkeeping including overall profit calculation.
     /// Once a bundle is closed this action cannot be reversed.
-    function _close(NftId bundleNftId)
+    function _closeBundle(NftId bundleNftId)
         internal
         virtual
     {

--- a/contracts/pool/PoolService.sol
+++ b/contracts/pool/PoolService.sol
@@ -180,8 +180,8 @@ contract PoolService is
         _componentService.decreasePoolBalance(
             instance.getInstanceStore(), 
             poolNftId, 
-            balanceAmount, 
-            feeAmount);
+            balanceAmount +  feeAmount, 
+            AmountLib.zero());
         
         emit LogPoolServiceBundleClosed(instance.getNftId(), poolNftId, bundleNftId);
 

--- a/contracts/pool/PoolService.sol
+++ b/contracts/pool/PoolService.sol
@@ -17,7 +17,7 @@ import {IStaking} from "../staking/IStaking.sol";
 
 import {Amount, AmountLib} from "../type/Amount.sol";
 import {Fee, FeeLib} from "../type/Fee.sol";
-import {NftId, NftIdLib} from "../type/NftId.sol";
+import {NftId} from "../type/NftId.sol";
 import {ObjectType, POOL, BUNDLE, COMPONENT, INSTANCE, REGISTRY} from "../type/ObjectType.sol";
 import {RoleId, PUBLIC_ROLE} from "../type/RoleId.sol";
 import {Fee, FeeLib} from "../type/Fee.sol";

--- a/contracts/pool/PoolService.sol
+++ b/contracts/pool/PoolService.sol
@@ -175,17 +175,17 @@ contract PoolService is
         // TODO get performance fee for pool (#477)
 
         // releasing collateral in bundle
-        (Amount balanceAmount, Amount feeAmount) = _bundleService.close(instance, bundleNftId);
+        (Amount unstakedAmount, Amount feeAmount) = _bundleService.close(instance, bundleNftId);
 
         _componentService.decreasePoolBalance(
             instance.getInstanceStore(), 
             poolNftId, 
-            balanceAmount +  feeAmount, 
+            unstakedAmount +  feeAmount, 
             AmountLib.zero());
         
         emit LogPoolServiceBundleClosed(instance.getNftId(), poolNftId, bundleNftId);
 
-        {
+        if ((unstakedAmount + feeAmount).gtz()){
             IComponents.ComponentInfo memory poolComponentInfo = instance.getInstanceReader().getComponentInfo(poolNftId);
             TokenHandler tokenHandler = poolComponentInfo.tokenHandler;
             IERC20Metadata token = IERC20Metadata(poolComponentInfo.token);
@@ -194,13 +194,17 @@ contract PoolService is
             
             // check allowance
             uint256 tokenAllowance = token.allowance(poolComponentInfo.wallet, address(tokenHandler));
-            if (tokenAllowance < (balanceAmount.toInt() +  feeAmount.toInt())) {
-                revert ErrorPoolServiceWalletAllowanceTooSmall(poolComponentInfo.wallet, address(tokenHandler), tokenAllowance, balanceAmount.toInt() + feeAmount.toInt());
+            if (tokenAllowance < (unstakedAmount.toInt() +  feeAmount.toInt())) {
+                revert ErrorPoolServiceWalletAllowanceTooSmall(
+                    poolComponentInfo.wallet, 
+                    address(tokenHandler), 
+                    tokenAllowance, 
+                    unstakedAmount.toInt() + feeAmount.toInt());
             }
 
             // transfer amount to bundle owner
             address bundleOwner = getRegistry().ownerOf(bundleNftId);
-            tokenHandler.transfer(poolComponentInfo.wallet, bundleOwner, balanceAmount + feeAmount);
+            tokenHandler.transfer(poolComponentInfo.wallet, bundleOwner, unstakedAmount + feeAmount);
         }
     }
 

--- a/test/TestBundle.t.sol
+++ b/test/TestBundle.t.sol
@@ -17,6 +17,8 @@ import {ObjectType, BUNDLE} from "../contracts/type/ObjectType.sol";
 import {Pool} from "../contracts/pool/Pool.sol";
 import {IPoolService} from "../contracts/pool/IPoolService.sol";
 import {POOL_OWNER_ROLE, PUBLIC_ROLE} from "../contracts/type/RoleId.sol";
+import {ReferralLib} from "../contracts/type/Referral.sol";
+import {RiskId, RiskIdLib} from "../contracts/type/RiskId.sol";
 import {Seconds, SecondsLib} from "../contracts/type/Seconds.sol";
 import {SimplePool} from "./mock/SimplePool.sol";
 import {StateId, ACTIVE, PAUSED, CLOSED} from "../contracts/type/StateId.sol";
@@ -610,7 +612,7 @@ contract TestBundle is GifTest {
         pool.extend(bundleNftId, lifetime);
     }
 
-    /// @dev test staking of an existing bundle 
+    /// @dev test closing of a bundle
     function test_Bundle_closeBundle() public {
         // GIVEN
         initialStakingFee = FeeLib.percentageFee(4);
@@ -648,6 +650,109 @@ contract TestBundle is GifTest {
 
         assertTrue(instanceReader.getBundleState(bundleNftId) == CLOSED(), "bundle not closed");
         assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
+    }
+
+    /// @dev test closing of a bundle with a closed policy (no staking fee)
+    function test_Bundle_closeBundle_withClosedPolicy() public {
+        // GIVEN - pool (no staking fee), a bundle with 3% fee and a closed policy
+        initialBundleFee = FeeLib.percentageFee(3);
+        _prepareProduct(true);
+        vm.stopPrank();
+
+        vm.startPrank(productOwner);
+        RiskId riskId = RiskIdLib.toRiskId("the risk");
+        product.createRisk(riskId, "");
+        vm.stopPrank();
+
+        vm.startPrank(customer);
+        NftId policyNftId = product.createApplication(
+            customer, 
+            riskId, 
+            1000 * 10 ** 6, 
+            SecondsLib.toSeconds(30 * 24 * 60 * 60), 
+            "", 
+            bundleNftId, 
+            ReferralLib.zero());
+        token.approve(address(product.getTokenHandler()), 1000 * 10 ** 6);
+        vm.stopPrank();
+
+        vm.startPrank(productOwner);
+        product.collateralize(policyNftId, true, TimestampLib.blockTimestamp());
+        product.expire(policyNftId, TimestampLib.zero());
+        product.close(policyNftId);
+        vm.stopPrank();
+        
+        IComponents.ComponentInfo memory poolComponentInfo = instanceReader.getComponentInfo(poolNftId);
+
+        assertTrue(!bundleNftId.eqz(), "bundle nft id is zero");
+
+        assertEq(token.balanceOf(poolComponentInfo.wallet), (DEFAULT_BUNDLE_CAPITALIZATION + 100 + 3 + 3)* 10 ** 6 , "pool wallet token balance not 100000 + 100 + 3");
+        uint256 investorBalanceBefore = token.balanceOf(investor);
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (DEFAULT_BUNDLE_CAPITALIZATION + 100 + 3 + 3) * 10 ** 6, "pool balance not 100000 + 100 + 3");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3) * 10 ** 6, "pool fees not 3");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), (100000 + 100 + 3) * 10 ** 6, "bundle balance not 96100");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 3 * 10 ** 6, "bundle fees 3");
+
+        vm.startPrank(investor);
+
+        // WHEN - bundle is closed
+        pool.closeBundle(bundleNftId);
+
+        // THEN - assert all counters are updated and tokens moved
+        assertEq(token.balanceOf(poolComponentInfo.wallet), 3 * 10 ** 6, "pool wallet token balance not 3");
+        uint256 investorBalanceAfter = token.balanceOf(investor);
+        assertEq(investorBalanceAfter, investorBalanceBefore + (100000 + 100 + 3) * 10 ** 6, "investor token balance not increased by 100000 + 100 + 3");
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), 3 * 10 ** 6, "pool balance not 3");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), 0, "pool fees not 0");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0");
+
+        assertTrue(instanceReader.getBundleState(bundleNftId) == CLOSED(), "bundle not closed");
+        assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
+    }
+
+    /// @dev test closing of a bundle with an open policy
+    function test_Bundle_closeBundle_openPolicy() public {
+        // GIVEN
+        initialBundleFee = FeeLib.percentageFee(3);
+        _prepareProduct(true);
+        vm.stopPrank();
+
+        vm.startPrank(productOwner);
+        RiskId riskId = RiskIdLib.toRiskId("the risk");
+        product.createRisk(riskId, "");
+        vm.stopPrank();
+
+        vm.startPrank(customer);
+        NftId policyNftId = product.createApplication(
+            customer, 
+            riskId, 
+            1000 * 10 ** 6, 
+            SecondsLib.toSeconds(30 * 24 * 60 * 60), 
+            "", 
+            bundleNftId, 
+            ReferralLib.zero());
+        token.approve(address(product.getTokenHandler()), 1000 * 10 ** 6);
+        vm.stopPrank();
+
+        vm.startPrank(productOwner);
+        product.collateralize(policyNftId, true, TimestampLib.blockTimestamp());
+        vm.stopPrank();
+
+        vm.startPrank(investor);
+
+        // THEN
+        vm.expectRevert(abi.encodeWithSelector(
+            IBundleService.ErrorBundleServiceBundleWithOpenPolicies.selector, 
+            bundleNftId,
+            1));
+
+        // WHEN
+        pool.closeBundle(bundleNftId);
     }
 
     function _fundInvestor(uint256 amount) internal {

--- a/test/TestBundle.t.sol
+++ b/test/TestBundle.t.sol
@@ -832,6 +832,54 @@ contract TestBundle is GifTest {
         assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
     }
 
+    /// @dev test closing of a bundle with a closed policy and no fees (fee withdrawal before close)
+    function test_Bundle_closeBundle_withClosedPolicyUnstakedAndWithdrawFeesBeforeClose() public {
+        // GIVEN - pool (3% staking fee), a bundle (6% fee) and a closed policy
+        initialStakingFee = FeeLib.percentageFee(3);
+        initialBundleFee = FeeLib.percentageFee(6);
+        _prepareProduct(true);
+        vm.stopPrank();
+
+        RiskId riskId = _createRisk("the risk");
+        _sellCollateralizeAndClosePolicy(riskId, 1000 * 10 ** 6, 30 * 24 * 60 * 60);
+
+        vm.startPrank(investor);
+        pool.withdrawBundleFees(bundleNftId, AmountLib.max());
+        pool.unstake(bundleNftId, AmountLib.max());
+        
+        IComponents.ComponentInfo memory poolComponentInfo = instanceReader.getComponentInfo(poolNftId);
+
+        assertTrue(!bundleNftId.eqz(), "bundle nft id is zero");
+
+        assertEq(token.balanceOf(poolComponentInfo.wallet), (3000 + 3) * 10 ** 6 , "pool wallet token balance not 3003");
+        uint256 investorBalanceBefore = token.balanceOf(investor);
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool balance not 3003");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool fees not 3009");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0");
+
+        vm.startPrank(investor);
+
+        // WHEN - bundle is closed
+        pool.closeBundle(bundleNftId);
+
+        // THEN - assert all counters are updated
+        assertEq(token.balanceOf(poolComponentInfo.wallet), (3000 + 3) * 10 ** 6, "pool wallet token balance not 3003 (2)");
+        uint256 investorBalanceAfter = token.balanceOf(investor);
+        assertEq(investorBalanceAfter, investorBalanceBefore, "investor token balance should not change");
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool balance not 3003 (2)");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool fees not 3003 (2)");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0 (2)");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0 (2)");
+
+        assertTrue(instanceReader.getBundleState(bundleNftId) == CLOSED(), "bundle not closed");
+        assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
+    }
+
     /// @dev test closing of a bundle with an open policy
     function test_Bundle_closeBundle_openPolicy() public {
         // GIVEN

--- a/test/TestBundle.t.sol
+++ b/test/TestBundle.t.sol
@@ -715,6 +715,49 @@ contract TestBundle is GifTest {
         assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
     }
 
+    /// @dev test closing of a bundle without any balance (full unstake before)
+    function test_Bundle_closeBundle_unstakeFullAmountBeforeClose() public {
+        // GIVEN - pool (3% staking fee), a bundle and no policy
+        initialStakingFee = FeeLib.percentageFee(3);
+        _prepareProduct(true);
+        vm.stopPrank();
+
+        vm.startPrank(investor);
+        pool.unstake(bundleNftId, AmountLib.max());
+        
+        IComponents.ComponentInfo memory poolComponentInfo = instanceReader.getComponentInfo(poolNftId);
+
+        assertTrue(!bundleNftId.eqz(), "bundle nft id is zero");
+
+        assertEq(token.balanceOf(poolComponentInfo.wallet), 3000 * 10 ** 6 , "pool wallet token balance not 3");
+        uint256 investorBalanceBefore = token.balanceOf(investor);
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), 3000 * 10 ** 6, "pool balance not 3000");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), 3000 * 10 ** 6, "pool fees not 3000");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0");
+
+        vm.startPrank(investor);
+
+        // WHEN - bundle is closed
+        pool.closeBundle(bundleNftId);
+
+        // THEN - assert all counters are updated, but no tokens moved
+        assertEq(token.balanceOf(poolComponentInfo.wallet), 3000 * 10 ** 6, "pool wallet token balance not 3 (2)");
+        uint256 investorBalanceAfter = token.balanceOf(investor);
+        assertEq(investorBalanceAfter, investorBalanceBefore, "investor token balance should not change");
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), 3000 * 10 ** 6, "pool balance not 3000");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), 3000 * 10 ** 6, "pool fees not 3000");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0");
+
+        assertTrue(instanceReader.getBundleState(bundleNftId) == CLOSED(), "bundle not closed");
+        assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
+    }
+
     /// @dev test closing of a bundle with an open policy
     function test_Bundle_closeBundle_openPolicy() public {
         // GIVEN

--- a/test/TestBundle.t.sol
+++ b/test/TestBundle.t.sol
@@ -740,7 +740,7 @@ contract TestBundle is GifTest {
 
     /// @dev test closing of a bundle with a closed policy and no balance (full unstake before close)
     function test_Bundle_closeBundle_withClosedPolicyUnstakeFullAmountBeforeClose() public {
-        // GIVEN - pool (3% staking fee), a bundle and no policy
+        // GIVEN - pool (3% staking fee), a bundle (6% bundle fee) and a closed policy
         initialStakingFee = FeeLib.percentageFee(3);
         initialBundleFee = FeeLib.percentageFee(6);
         _prepareProduct(true);
@@ -774,6 +774,53 @@ contract TestBundle is GifTest {
         assertEq(token.balanceOf(poolComponentInfo.wallet), (3000 + 3) * 10 ** 6, "pool wallet token balance not 3003 (2)");
         uint256 investorBalanceAfter = token.balanceOf(investor);
         assertEq(investorBalanceAfter, investorBalanceBefore + 6 * 10 ** 6, "investor token balance should be increased by 6");
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool balance not 3003 (2)");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool fees not 3003 (2)");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), 0, "bundle balance not 0 (2)");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0 (2)");
+
+        assertTrue(instanceReader.getBundleState(bundleNftId) == CLOSED(), "bundle not closed");
+        assertTrue(instanceBundleSet.activeBundles(poolNftId) == 0, "active bundles not 0");
+    }
+
+    /// @dev test closing of a bundle with a closed policy and no fees (fee withdrawal before close)
+    function test_Bundle_closeBundle_withClosedPolicyWithdrawFeesBeforeClose() public {
+        // GIVEN - pool (3% staking fee), a bundle (6% fee) and a closed policy
+        initialStakingFee = FeeLib.percentageFee(3);
+        initialBundleFee = FeeLib.percentageFee(6);
+        _prepareProduct(true);
+        vm.stopPrank();
+
+        RiskId riskId = _createRisk("the risk");
+        _sellCollateralizeAndClosePolicy(riskId, 1000 * 10 ** 6, 30 * 24 * 60 * 60);
+
+        vm.startPrank(investor);
+        pool.withdrawBundleFees(bundleNftId, AmountLib.max());
+        
+        IComponents.ComponentInfo memory poolComponentInfo = instanceReader.getComponentInfo(poolNftId);
+
+        assertTrue(!bundleNftId.eqz(), "bundle nft id is zero");
+
+        assertEq(token.balanceOf(poolComponentInfo.wallet), (97000 + 100 + 3000 + 3) * 10 ** 6 , "pool wallet token balance not 100103");
+        uint256 investorBalanceBefore = token.balanceOf(investor);
+
+        assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (97000 + 100 + 3000 + 3) * 10 ** 6, "pool balance not 100103");
+        assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool fees not 3009");
+
+        assertEq(instanceReader.getBalanceAmount(bundleNftId).toInt(), (97100) * 10 ** 6, "bundle balance not 97100");
+        assertEq(instanceReader.getFeeAmount(bundleNftId).toInt(), 0, "bundle fees 0");
+
+        vm.startPrank(investor);
+
+        // WHEN - bundle is closed
+        pool.closeBundle(bundleNftId);
+
+        // THEN - assert all counters are updated
+        assertEq(token.balanceOf(poolComponentInfo.wallet), (3000 + 3) * 10 ** 6, "pool wallet token balance not 3003 (2)");
+        uint256 investorBalanceAfter = token.balanceOf(investor);
+        assertEq(investorBalanceAfter, investorBalanceBefore + 97100 * 10 ** 6, "investor token balance should be increased by 97100");
 
         assertEq(instanceReader.getBalanceAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool balance not 3003 (2)");
         assertEq(instanceReader.getFeeAmount(poolNftId).toInt(), (3000 + 3) * 10 ** 6, "pool fees not 3003 (2)");

--- a/test/TestBundle.t.sol
+++ b/test/TestBundle.t.sol
@@ -887,10 +887,7 @@ contract TestBundle is GifTest {
         _prepareProduct(true);
         vm.stopPrank();
 
-        vm.startPrank(productOwner);
-        RiskId riskId = RiskIdLib.toRiskId("the risk");
-        product.createRisk(riskId, "");
-        vm.stopPrank();
+        RiskId riskId = _createRisk("the risk");
 
         vm.startPrank(customer);
         NftId policyNftId = product.createApplication(
@@ -915,6 +912,36 @@ contract TestBundle is GifTest {
             IBundleService.ErrorBundleServiceBundleWithOpenPolicies.selector, 
             bundleNftId,
             1));
+
+        // WHEN
+        pool.closeBundle(bundleNftId);
+    }
+
+    /// @dev test closing of a bundle
+    function test_Bundle_closeBundle_allowanceTooSmall() public {
+        // GIVEN
+        initialStakingFee = FeeLib.percentageFee(4);
+        _prepareProduct(true);
+        
+        IComponents.ComponentInfo memory poolComponentInfo = instanceReader.getComponentInfo(poolNftId);
+
+        assertTrue(!bundleNftId.eqz(), "bundle nft id is zero");
+
+        address externalWallet = makeAddr("externalWallet");
+
+        vm.startPrank(poolOwner);
+        pool.setWallet(externalWallet);
+        vm.stopPrank();
+        
+        vm.startPrank(investor);
+
+        // THEN - expect revert
+        vm.expectRevert(abi.encodeWithSelector(
+            IPoolService.ErrorPoolServiceWalletAllowanceTooSmall.selector, 
+            externalWallet,
+            address(pool.getTokenHandler()),
+            0,
+            96000 * 10 ** 6));
 
         // WHEN
         pool.closeBundle(bundleNftId);

--- a/test/TestPool.t.sol
+++ b/test/TestPool.t.sol
@@ -300,7 +300,7 @@ contract TestPool is GifTest {
 
         // WHEN close bundle
         vm.prank(investor);
-        pool.close(bundleNftId);
+        pool.closeBundle(bundleNftId);
 
         // THEN
         metadata = instanceReader.getMetadata(bundleKey);

--- a/test/base/GifTest.sol
+++ b/test/base/GifTest.sol
@@ -173,7 +173,7 @@ contract GifTest is GifDeployer {
     uint8 initialProductFeePercentage = 2;
     uint8 initialPoolFeePercentage = 3;
     uint8 initialStakingFeePercentage = 0;
-    uint8 initialBundleFeePercentage = 4;
+    uint8 initialBundleFeePercentage = 0;
     uint8 initialDistributionFeePercentage = 20;
     uint8 initialMinDistributionOwnerFeePercentage = 2;
 
@@ -487,7 +487,7 @@ contract GifTest is GifDeployer {
             token.approve(address(poolComponentInfo.tokenHandler), DEFAULT_BUNDLE_CAPITALIZATION * 10**token.decimals());
 
             (bundleNftId,) = SimplePool(address(pool)).createBundle(
-                FeeLib.zero(), 
+                initialBundleFee, 
                 DEFAULT_BUNDLE_CAPITALIZATION * 10**token.decimals(), 
                 SecondsLib.toSeconds(DEFAULT_BUNDLE_LIFETIME), 
                 ""


### PR DESCRIPTION
# tests

- [x] open/close bundle - check all counter amounts and balances
- [x] open bundle/create policy/close policy/close bundle - check all counter amounts and balances
- [x] open/unstake full amount/close bundle - check all counter amounts and balances
- [x] open/create policy/close policy/unstake full amount/close bundle - check all counter amounts and balances
- [x] open/create policy/close policy/withdraw fees/close bundle - check all counter amounts and balances
- [x] close bundle with remaining balance and fees zero (withdraw fees and unstake full) 
- [x] close bundle with open policy - revert
- [x] close bundle with token allowance too small - revert
- [x] close as not owner - revert
